### PR TITLE
Fix issue with gem initialization. Fix #text_to_image method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ client = StabilityAI::Client.new
 
 # Text to image
 text_to_image_response = client.text_to_image('engine_id', text_prompts: [{ text: 'A lighthouse on a cliff' }])
-uri_image_1 = text_to_image_response.image_uris.first           # ->  <img src="#{uri_image_1}"/>  or image_tag(uri_image_1)
-text_to_image_response.save_images('your_image_name_prefix')  # -> returns ["your_image_name_prefix_1.png", "your_image_name_prefix_2.png", ...]
+text_to_image_response.save_images(filename_prefix: 'your_image_name_prefix')  # -> returns ["your_image_name_prefix_1.png", "your_image_name_prefix_2.png", ...]
 
 # Image to image
 

--- a/lib/stability_ai/api/generation.rb
+++ b/lib/stability_ai/api/generation.rb
@@ -4,8 +4,10 @@ require "rmagick"
 module StabilityAI
   module API
     module Generation
-      def text_to_image(engine_id: nil, options: {})
-        response = self.class.post("/v1/generation/#{get_engine_id(engine_id)}/text-to-image", body: options.to_json,
+      def text_to_image(engine_id:, text_prompts:, options: {})
+        body = { text_prompts: text_prompts }
+
+        response = self.class.post("/v1/generation/#{get_engine_id(engine_id)}/text-to-image", body: body.merge!(options).to_json,
                                                                                                headers: { "Content-Type" => "application/json" })
         handle_response(response)
       end
@@ -17,7 +19,7 @@ module StabilityAI
         image_payload = create_payload(image_binary, image_base64, image_path)
         image =         convert_and_resize_image(image_payload)
         temp_file =     create_temp_file_from_image(image)
-        form_data =     set_form_data(image:, endpoint: :image_to_image, options:, temp_file:)
+        form_data =     set_form_data(image: image, endpoint: :image_to_image, options: options, temp_file: temp_file)
 
         default_weight = options[:text_prompts].count > 1 ? (1 / options[:text_prompts].count).round(2) : 1
         options[:text_prompts].each_with_index do |text_prompt, i|
@@ -42,7 +44,7 @@ module StabilityAI
         image_payload = create_payload(image_binary, image_base64, image_path)
         image =         convert_and_resize_image(image_payload)
         temp_file =     create_temp_file_from_image(image)
-        form_data =     set_form_data(image:, endpoint: :image_to_image_upscale, options: options, temp_file:)
+        form_data =     set_form_data(image: image, endpoint: :image_to_image_upscale, options: options, temp_file: temp_file)
 
         headers = { "Content-Type" => "multipart/form-data" }
         response = self.class.post("/v1/generation/#{engine_id}/image-to-image/upscale", headers: headers, multipart: true, body: form_data)

--- a/lib/stability_ai/response/image_response.rb
+++ b/lib/stability_ai/response/image_response.rb
@@ -19,7 +19,7 @@ module StabilityAI
       end
 
       def save_images(filename_prefix: nil)
-        filename_prefix = Time.now.utc.strftime("%Y%m%d%H%M%S") if filename_prefix.nil?
+        filename_prefix = filename_prefix || Time.now.utc.strftime("%Y%m%d%H%M%S")
         downloaded_images = []
         path_prefix = StabilityAI.configuration.path_prefix
         @artifacts.each_with_index do |artifact, i|


### PR DESCRIPTION
There was an error when trying to run bin/console

```
bin/console                                                                                           ok | 2.7.2 rb | at 01:27:50 AM
Traceback (most recent call last):
	3: from bin/console:5:in `<main>'
	2: from bin/console:5:in `require'
	1: from /stability_ai/lib/stability_ai.rb:12:in `<top (required)>'
/stability_ai/lib/stability_ai.rb:12:in `require_relative': /stability_ai/lib/stability_ai/api/generation.rb:20: syntax error, unexpected ',' (SyntaxError)
...ata =     set_form_data(image:, endpoint: :image_to_image, o...
...                              ^
/stability_ai/lib/stability_ai/api/generation.rb:45: syntax error, unexpected ','
...ata =     set_form_data(image:, endpoint: :image_to_image_up...
```

- Fix text_to_image method so it builds the payload with the text_prompts